### PR TITLE
header logo path and alt text

### DIFF
--- a/development/config.rb
+++ b/development/config.rb
@@ -1,5 +1,7 @@
 AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels']
 AppConfig[:emory_ga_tracking_public] = ''
+AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
+AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'
 AppConfig[:container_management_labels_pagesize] = {
     "avery-5163" => {
         "size" => "letter",

--- a/production/config.rb
+++ b/production/config.rb
@@ -1,5 +1,7 @@
 AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels']
 AppConfig[:emory_ga_tracking_public] = 'G-83TR9951KC'
+AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
+AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'
 AppConfig[:container_management_labels_pagesize] = {
     "avery-5163" => {
         "size" => "letter",

--- a/test/config.rb
+++ b/test/config.rb
@@ -1,5 +1,7 @@
 AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels']
 AppConfig[:emory_ga_tracking_public] = 'G-83TR9951KC'
+AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
+AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'
 AppConfig[:container_management_labels_pagesize] = {
     "avery-5163" => {
         "size" => "letter",


### PR DESCRIPTION
adds header logo path and alt text. 

ticket referencer #12: https://app.zenhub.com/workspaces/archivesspace-63122393d517dc001c3ceb07/issues/gh/emory-libraries/aspace/12