### PR TITLE
Upgrade ArchivesSpace to 3.5.0

### DIFF
--- a/development/config.rb
+++ b/development/config.rb
@@ -1,6 +1,6 @@
 AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels', 'lcnaf', 'aeon-fulfillment-plugin', 'uga-archivesspace-reports']
 AppConfig[:public_url] = "http://localhost:3001"
-# AppConfig[:archivesspace_version] = "3.3.1"
+# AppConfig[:archivesspace_version] = "3.5.0"
 AppConfig[:emory_ga_tracking_public] = ''
 AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
 AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'

--- a/production/config.rb
+++ b/production/config.rb
@@ -1,10 +1,10 @@
 # AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels', 'lcnaf', 'aeon-fulfillment-plugin', 'uga-archivesspace-reports']
 # AppConfig[:public_url] = "https://archives.libraries.emory.edu"
-# AppConfig[:archivesspace_version] = "3.3.1"
+# AppConfig[:archivesspace_version] = "3.5.0"
 AppConfig[:emory_ga_tracking_public] = 'G-83TR9951KC'
 AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
 AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'
-AppConfig[:emory_plugins_version] = 'v2023-05-24'
+AppConfig[:emory_plugins_version] = 'v2023-07-10'
 AppConfig[:container_management_labels_pagesize] = {
     "avery-5163" => {
         "size" => "letter",

--- a/production/plugins.yml
+++ b/production/plugins.yml
@@ -1,7 +1,7 @@
 plugins:
   - name: aspace_static_plugins
     git: true
-    branch: "v2.0.1"
+    branch: "v2.1.0"
     url: https://github.com/emory-libraries/aspace_static_plugins.git
   - name: container_management_labels
     git: true

--- a/test/config.rb
+++ b/test/config.rb
@@ -1,6 +1,6 @@
 # AppConfig[:plugins] = ['aspace_static_plugins', 'container_management_labels', 'lcnaf', 'aeon-fulfillment-plugin', 'uga-archivesspace-reports']
 # AppConfig[:public_url] = "https://archives-test.libraries.emory.edu"
-# AppConfig[:archivesspace_version] = "3.3.1"
+# AppConfig[:archivesspace_version] = "3.5.0"
 AppConfig[:emory_ga_tracking_public] = 'G-83TR9951KC'
 AppConfig[:pui_branding_img] = '/assets/images/shield.svg'
 AppConfig[:pui_branding_img_alt_text] = 'Emory University Libraries Logo'


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/archivesspace-63122393d517dc001c3ceb07/issues/gh/emory-libraries/aspace/176

Note: The production instance was updated to v2023-07-10 back in July, but we never updated the production configuration to reflect that change. I made that change in this PR as well to ensure the configuration in file reflects what is currently deployed.